### PR TITLE
Use cache-dir! to keep bower files between invocations.

### DIFF
--- a/src/degree9/boot_bower.clj
+++ b/src/degree9/boot_bower.clj
@@ -13,13 +13,14 @@
   [i install     FOO=BAR {kw str} "Dependency map."
    d directory   VAL     str      "Directory to install components (defaults to 'bower_components' in target)"
    g ignore      VAL     #{kw}    "List of packages to ignore."
-   r resolutions VAL     {kw str} "Dependency resolutions."]
+   r resolutions VAL     {kw str} "Dependency resolutions."
+   c cache-key   VAL     kw       "Optional cache key -  in case bower is used for various dependency sets)." ]
   (let [deps         (or (:install     *opts*) "")
         dir          (or (:directory   *opts*) "/bower_components")
         ignore       (or (:ignore      *opts*) "")
         res          (or (:resolutions *opts*) "")
-        tmp          (boot/tmp-dir!)
-        tmpbwr       (boot/tmp-dir!)
+        cache-key    (:cache-key *opts* ::cache-key)
+        tmp          (boot/cache-dir! cache-key)
         bwrjson      (generate-string {:name ::tmp :dependencies deps :resolutions res} {:pretty true})
         bwrrc        (generate-string {:directory dir :ignoredDependencies ignore} {:pretty true})
         jsonf        (io/file tmp "bower.json")
@@ -32,10 +33,10 @@
     (boot/with-pre-wrap fileset
        (doto jsonf  io/make-parents (spit bwrjson))
        (doto bwrrcf io/make-parents (spit bwrrc))
+       (util/info (clojure.string/join ["Running bower: " bwrcmd "\n"]))
        (let [cmdresult   @(exec/sh [bwrcmd "install" "--allow-root"] {:dir (.getPath tmp)})
              exitcode    (:exit cmdresult)
              errormsg    (:err cmdresult)]
-         (util/info (clojure.string/join ["Bower found at...: " bwrcmd "\n"]))
          (assert (= 0 exitcode) (util/fail (clojure.string/join ["Bower failed with...: \n" errormsg "\n"])))
          (util/info "Bower run successful...\n")
          (-> fileset (boot/add-resource tmp) boot/commit!)))))


### PR DESCRIPTION
This allows bower to optimize and not re-fetch the deps every time.

At the beginning I thought about making it optional, but then I thought that bower should work just fine with (possibly stale) existing files. 
